### PR TITLE
testing with arduino until it works

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,111 @@ Typical usage will follow the following flow:
 In the future, Arduino and Furi (Flipper Zero) library interfaces may be provided.
 
 # Examples
+Examples coming soon.
 
 ## Arduino
 
+### Step One
+
+```c
+#include <sgp30.h>
+#include <sgp30_defs.h>
+
+#include <assert.h>
+#include <Wire.h>
+
+Sgp30Dev* dev;
+
+SGP30_INTF_RET_TYPE device_read(uint8_t reg, uint8_t* data, uint32_t data_len, void* intf_ptr);
+SGP30_INTF_RET_TYPE device_write(uint8_t reg, uint8_t* command, uint32_t data_len, void* intf_ptr);
+void device_delay_us(uint32_t period, void* intf_ptr);
+```
+
+Arduino uses a library called `Wire` that provides an interface for I2C communication. 
+
+We will set the read and write addresses to `SGP30_I2C_ADDR` and the `Wire` library will do the rest.
+
+Import headers, declare a global device pointer `dev` and prototype read/write/delay functions.
+
+### Step Two
+
+In `setup()`
+
+```c
+void setup() {
+  // put your setup code here, to run once:
+  Serial.begin(115200);
+  delay(2000);
+  Wire.begin(dev->i2c_addr);
+
+  dev = sgp30_alloc();
+
+  sgp30_set_read_fptr(dev, device_read);
+  sgp30_set_write_fptr(dev, device_write);
+  sgp30_set_delay_us_fptr(dev, device_delay_us);
+  sgp30_set_i2c_addr_read(dev, SGP30_I2C_ADDR);
+  sgp30_set_i2c_addr_write(dev, SGP30_I2C_ADDR);
+```
+
+Initialize Wire communication and allocate a device.
+
+Next we set the read/write/delay function pointers, and the I2C read and write addresses that work with the `Wire` library. 
+
+### Step Three
+
+```c
+uint8_t status = sgp30_read_chip_id(dev);
+```
+
+Initiate a read test
+
+### Step Four
+
+```c
+status = sgp30_measure_test(dev);
+```
+
+Initiate a measure test, and *check the return code*.
+
+#### Step Five
+
+```c
+status = sgp30_init(dev);
+```
+
+Initialize the sensor. Setup is complete.
+
+### Step Five
+
+The main function, `loop()``
+
+```c
+void loop() {
+  // put your main code here, to run repeatedly:
+  Sgp30DevReadings readings = { 0 };
+
+  int8_t status = sgp30_measure_air_quality(dev, &readings);
+  ... HANDLE YOUR ERRORS ...
+  
+  char out_buf[32];
+  snprintf(out_buf,
+           sizeof(out_buf),
+           "co_eq: %u, tvoc: %u",
+           readings.co2,
+           readings.tvoc);
+  Serial.println(out_buf);
+  
+  delay(1000);
+}
+```
+
+1. Pass the `dev` pointer and a `Sgp30DevReadings` pointer to `sgp30_measure_air_quality`. The results are stored in the readings object.
+2. Access the measurements in
+    * `readings.co2` - CO2_eq
+    * `readings.tvoc` - Total volatile organic compounds
+3. wait 1 second!
+
+The readings must be done in a frequency of 1Hz to maintain calibration (calibration settings support coming soon).
+
 ## Flipper Zero
+Coming soon

--- a/src/sgp30.h
+++ b/src/sgp30.h
@@ -98,6 +98,32 @@ int8_t sgp30_set_write_fptr(Sgp30Dev* dev, sgp30_write_fptr_t fptr);
 int8_t sgp30_set_delay_us_fptr(Sgp30Dev* dev, sgp30_delay_us_fptr_t fptr);
 
 /**
+ * @brief Set I2C read address
+ * 
+ * Default is as defined in the datasheet.
+ * 
+ * @param[in] addr_read : Byte address of the new read register
+ * 
+ * @return Success of setting register value
+ * @retval 0 on success
+ * @retval < 0 on failure
+ */
+int8_t sgp30_set_i2c_addr_read(Sgp30Dev* dev, uint8_t addr_read);
+
+/**
+ * @brief Set I2C write address
+ * 
+ * Default is as defined in the datasheet.
+ * 
+ * @param[in] addr_write : Byte address of the new read register
+ * 
+ * @return Success of setting register value
+ * @retval 0 on success
+ * @retval < 0 on failure
+ */
+int8_t sgp30_set_i2c_addr_write(Sgp30Dev* dev, uint8_t addr_write);
+
+/**
  * @brief Initialize Sgp30 instance.
  * 
  * Read Chip ID and initialize measurement data.
@@ -111,9 +137,9 @@ int8_t sgp30_set_delay_us_fptr(Sgp30Dev* dev, sgp30_delay_us_fptr_t fptr);
 int8_t sgp30_init(Sgp30Dev* dev);
 
 /**
- * @brief Free a Sgp30 instance.
+ * @brief Free a Sgp30dev instance.
  *
- * @param[in]  dev : Pointer to a Sgp30 instance
+ * @param[in]  dev : Pointer to a Sgp30Dev pointer
  *
  * @return Void.
  */
@@ -124,7 +150,7 @@ void sgp30_free(Sgp30Dev** dev);
  * 
  * CRC checksum is not calculated for bytes read.
  *
- * @param[in]   dev      : Pointer to a Sgp30 instance
+ * @param[in]   dev      : Pointer to a Sgp30Dev
  * @param[out]  data     : Pointer to byte array to read data into
  * @param[in]   data_len : Number of bytes to read
  *

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -18,6 +18,20 @@ SGP30_INTF_RET_TYPE dummy_write_success(uint8_t reg, const uint8_t* data, uint32
 /* write fails */
 SGP30_INTF_RET_TYPE dummy_write_error(uint8_t reg, const uint8_t* data, uint32_t data_len, void* intf_ptr);
 
+/** measure_test test */
+/**
+ * @brief This function should always return 0xD400, with correct crc, for testing sg30_measure_test
+ */
+SGP30_INTF_RET_TYPE read_measure_test_success(uint8_t reg, uint8_t* data, uint32_t data_len, void* intf_ptr);
+
+/**
+ * @brief This function returns 0xD400 with an incorrect crc
+ */
+SGP30_INTF_RET_TYPE dummy_read_measure_test_wrong_crc(uint8_t reg, uint8_t* data, uint32_t data_len, void* intf_ptr);
+
+/* test CRC implementation CRC(0xBEEF) = 0x92 */
+void test_generate_crc(void);
+
 /* dummy delay */
 void dummy_delay_us(uint32_t period, void* intf_ptr);
 
@@ -30,11 +44,16 @@ void test_set_write_fptr_null_ptr(void);
 
 /* init tests */
 void test_init_dev_null(void);
-void test_init_device_not_found(void);
+void test_init_dev_success(void);
 
 /** double free */
 void test_double_free(void);
 
 void test_read(void);
+void test_write(void);
+
+/** measure test tests */
+void test_measure_test_fail_crc(void);
+void test_measure_test_success(void);
 
 #endif


### PR DESCRIPTION
Wire abstracts the read/write registers so I needed an interface to let users set them.

Adding some basic tests using dummy read and write functions.

README now has an Arduino example.

Dependency on <string.h> and <linux/string.h> was removed.; we can do memset/bzero by hand.

Fixed a timing issue in sgp30_measure_test.